### PR TITLE
Fixes silent postgres connection error

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "globaloffensive": "^2.1.0",
     "long": "^3.2.0",
     "mongodb": "^2.2.36",
-    "pg": "^7.18.2",
+    "pg": "^8.7.3",
     "simple-vdf": "^1.1.1",
     "socket.io": "^2.4.0",
     "steam-totp": "^1.5.0",


### PR DESCRIPTION
The current version of the pg dependency only supports node versions up to 14. If you have a node version > 14 it will silently throw an error and you will scratch your head on how to proceed.