### PR TITLE
Bumps Docker Node Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:18.15
 
 # Create app directory
 WORKDIR /usr/src/csgofloat


### PR DESCRIPTION
See https://github.com/DoctorMcKay/node-steam-user#legacy-authentication

Legacy auth applies to Node <v12.22, which breaks the `relog()` function. Bumping Node to v18 which make us use modern auth.

Using v18.15 for LTS Stable.

Fixes #117 for Docker