### PR TITLE
Enforces D Param Correctness in Lookup

### DIFF
--- a/lib/postgres.js
+++ b/lib/postgres.js
@@ -302,6 +302,7 @@ class Postgres {
 
     async _getItemData(links) {
         const aValues = links.map(e => utils.unsigned64ToSigned(e.getParams().a));
+        const dValues = links.map(e => utils.unsigned64ToSigned(e.getParams().d));
 
         const result = await this.pool.query(`
             SELECT *, 
@@ -326,7 +327,7 @@ class Postgres {
                         ORDER  BY J.paintwear DESC
                         LIMIT  1000) as b) AS high_rank 
             FROM   items S
-            WHERE  a= ANY($1::bigint[])`, [aValues]);
+            WHERE  a = ANY($1::bigint[]) AND d = ANY($2::bigint[])`, [aValues, dValues]);
 
         return result.rows.map((item) => {
             delete item.updated;


### PR DESCRIPTION
Some folks only have the asset ID and attempt to fetch an invalid inspect link with only the asset ID annotated in the hopes that our cache has it. 

This has the unintended side effect of overloading our queue when done across thousands of IPs.

This PR enforces that they also annotate the "D" param of the inspect link to prevent this use case.