### PR TITLE
Fixes `setResponseRemaining` to Always Set All Responses

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -38,7 +38,8 @@ class Job {
     }
 
     setResponseRemaining(response) {
-        for (const link of this.remainingLinks) {
+        // Prevent operating on mutating list size
+        for (const link of [...this.remainingLinks]) {
             this.setResponse(link.link.getParams().a, response);
         }
     }


### PR DESCRIPTION
Was previously looping over a list that was getting mutated within `setResponse`.

This could cause the request to never reply (only relevant for `/bulk` queries)