### PR TITLE
Revert "Enforces D Param Correctness in Lookup"

### DIFF
--- a/lib/postgres.js
+++ b/lib/postgres.js
@@ -302,7 +302,6 @@ class Postgres {
 
     async _getItemData(links) {
         const aValues = links.map(e => utils.unsigned64ToSigned(e.getParams().a));
-        const dValues = links.map(e => utils.unsigned64ToSigned(e.getParams().d));
 
         const result = await this.pool.query(`
             SELECT *, 
@@ -327,7 +326,7 @@ class Postgres {
                         ORDER  BY J.paintwear DESC
                         LIMIT  1000) as b) AS high_rank 
             FROM   items S
-            WHERE  a = ANY($1::bigint[]) AND d = ANY($2::bigint[])`, [aValues, dValues]);
+            WHERE  a= ANY($1::bigint[])`, [aValues]);
 
         return result.rows.map((item) => {
             delete item.updated;


### PR DESCRIPTION
Reverts csgofloat/inspect#127

Many items have a changed D Param in the last while, should instead enforce MS param correctness.