### PR TITLE
Distributes Request Load Evenly Across Bots

### DIFF
--- a/lib/bot_controller.js
+++ b/lib/bot_controller.js
@@ -1,4 +1,5 @@
 const Bot = require('./bot'),
+    utils = require('./utils'),
     EventEmitter = require('events').EventEmitter,
     errors = require('../errors');
 
@@ -32,7 +33,8 @@ class BotController extends EventEmitter {
     }
 
     getFreeBot() {
-        for (let bot of this.bots) {
+        // Shuffle array to evenly distribute requests
+        for (let bot of utils.shuffleArray(this.bots)) {
             if (!bot.busy && bot.ready) return bot;
         }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -109,3 +109,12 @@ exports.chunkArray = function (arr, size) {
     return new Array(Math.ceil(arr.length / size)).fill().map(_ => arr.splice(0,size));
 };
 
+/*
+    Shuffle array - O(N LOG N) so it shouldn't be used for super-large arrays
+ */
+exports.shuffleArray = function (arr) {
+    return arr.map(value => ({ value, sort: Math.random() }))
+        .sort((a, b) => a.sort - b.sort)
+        .map(({ value }) => value)
+}
+


### PR DESCRIPTION
Previously, requests would be given to the first available bot in the list, but the list was in a constant order.

This would cause some bots to have more load (and rate limits) than others.