### PR TITLE
Relogin on Proxy Timeout (during Steam maintenance)

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -104,6 +104,12 @@ class Bot extends EventEmitter {
             if (err.eresult && login_error_msgs[err.eresult] !== undefined) {
                 winston.error(this.username + ': ' + login_error_msgs[err.eresult]);
             }
+
+            // Yes, checking for string errors sucks, but we have no other attributes to check
+            // this error against.
+            if (err.toString().includes('Proxy connection timed out')) {
+                this.steamClient.relog();
+            }
         });
 
         this.steamClient.on('disconnected', (eresult, msg) => {


### PR DESCRIPTION
node-steam-user seems to have issues with reconnecting to the GC if a proxy timeout.